### PR TITLE
Test CKMS error bounds compared to known-good impl.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -282,6 +282,41 @@ mod test {
     use quickcheck::{QuickCheck, TestResult};
     use std::f64::consts::E;
 
+    fn percentile(data: &Vec<f64>, prcnt: f64) -> f64 {
+        let idx = (prcnt * (data.len() as f64)) as usize;
+        return data[idx];
+    }
+
+    #[test]
+    fn error_nominal_test() {
+        fn inner(mut data: Vec<f64>, prcnt: f64) -> TestResult {
+            data.sort_by(|a, b| a.partial_cmp(b).unwrap());
+            if !(prcnt >= 0.0) || !(prcnt <= 1.0) {
+                return TestResult::discard();
+            } else if data.len() < 1 {
+                return TestResult::discard();
+            }
+            let err = 0.001;
+
+            let mut ckms = CKMS::<f64>::new(err);
+            for d in &data {
+                ckms.insert(*d);
+            }
+
+            if let Some((_, v)) = ckms.query(prcnt) {
+                debug_assert!((v - percentile(&data, prcnt)) < err,
+                              "v: {} | percentile: {} | prcnt: {} | data: {:?}", v, percentile(&data, prcnt), prcnt, data);
+                TestResult::passed()
+            } else {
+                TestResult::failed()
+            }
+        }
+        QuickCheck::new()
+            .tests(10000)
+            .max_tests(100000)
+            .quickcheck(inner as fn(Vec<f64>, f64) -> TestResult);
+    }
+
     #[test]
     fn n_invariant_test() {
         fn n_invariant(fs: Vec<i64>) -> bool {
@@ -299,6 +334,7 @@ mod test {
             .max_tests(100000)
             .quickcheck(n_invariant as fn(Vec<i64>) -> bool);
     }
+
     // prop: forany phi. (phi*n - f(phi*n, n)/2) =< r_i =< (phi*n + f(phi*n, n)/2)
     #[test]
     fn query_invariant_test() {


### PR DESCRIPTION
This commit adds error_nominal_test to assert that the configured
error bound is obeyed by the CKMS structure. We test this by
comparing percentiles computed against a sorted data set.

The code in the commit is relatively straightforward and no issues
were uncovered with the CKMS implementation.

Signed-off-by: Brian L. Troutwine <blt@postmates.com>