### PR TITLE
Introduce a cummulative moving average to CKMS

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,7 +9,7 @@
         missing_debug_implementations, missing_copy_implementations,
         unsafe_code,
         unstable_features,
-        unused_import_braces, unused_qualifications)]
+        unused_import_braces)]
 
 #[cfg(test)]
 #[macro_use]


### PR DESCRIPTION
This commit introduces a cummulative moving average and supporting
QC tests to CKMS. It also includes a fair bit of rehuffling due to
rustfmt but the main deal is really down in src/ckms.

Of particular interest we've had to enforce conversion of T to f64.
This means that some types like i64 are no longer available for use
with the CKMS. Fully generic numeric code is hard in Rust. :/

Signed-off-by: Brian L. Troutwine <blt@postmates.com>