### PR TITLE
Upgrade Serde, make optional

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "quantiles"
-version = "0.4.0"
+version = "0.5.0"
 authors = ["Brian L. Troutwine <blt@postmates.com>"]
 
 description = "a collection of approximate quantile algorithms"
@@ -18,6 +18,6 @@ lto = true
 quickcheck = "0.4"
 
 [dependencies]
-serde = "0.9"
-serde_derive = "0.9"
+serde = "1.0"
+serde_derive = "1.0"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,10 @@ lto = true
 quickcheck = "0.4"
 
 [dependencies]
-serde = "1.0"
-serde_derive = "1.0"
+serde = { version = "1.0", optional = true }
+serde_derive = { version = "1.0", optional = true }
 
+[features]
+default = []
+
+serde_support = ["serde", "serde_derive"]

--- a/benches/insert.rs
+++ b/benches/insert.rs
@@ -9,7 +9,7 @@ use quantiles::ckms::CKMS;
 #[bench]
 fn bench_sequential_insert(b: &mut Bencher) {
     b.iter(|| {
-               let mut ckms = CKMS::<i64>::new(0.001);
+               let mut ckms = CKMS::<i32>::new(0.001);
                for i in 0..10000 {
                    ckms.insert(i);
                }
@@ -21,7 +21,7 @@ fn bench_sequential_insert(b: &mut Bencher) {
 fn bench_inverted_insert(b: &mut Bencher) {
     b.iter(|| {
                let seq = (0..10000).rev();
-               let mut ckms = CKMS::<i64>::new(0.001);
+               let mut ckms = CKMS::<i32>::new(0.001);
                for i in seq {
                    ckms.insert(i);
                }

--- a/src/ckms.rs
+++ b/src/ckms.rs
@@ -16,7 +16,8 @@ use std::cmp;
 use std::fmt::Debug;
 use std::ops::{Add, AddAssign, Div, Sub};
 
-#[derive(Debug,Clone,PartialEq, Serialize, Deserialize)]
+#[derive(Debug,Clone,PartialEq)]
+#[cfg_attr(feature = "serde_support", derive(Serialize, Deserialize))]
 struct Entry<T: Copy> {
     v: T,
     g: usize,
@@ -25,7 +26,8 @@ struct Entry<T: Copy> {
 
 /// A structure to provide approximate quantiles queries in bounded memory and
 /// with bounded error.
-#[derive(Clone, PartialEq, Debug, Serialize, Deserialize)]
+#[derive(Clone, PartialEq, Debug)]
+#[cfg_attr(feature = "serde_support", derive(Serialize, Deserialize))]
 pub struct CKMS<T: Copy> {
     n: usize,
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,6 +15,7 @@
 #[macro_use]
 extern crate quickcheck;
 
+#[cfg(feature = "serde_support")]
 #[macro_use]
 extern crate serde_derive;
 

--- a/src/misra_gries.rs
+++ b/src/misra_gries.rs
@@ -74,7 +74,7 @@ pub fn misra_gries<I, V>(stream: I, k: usize) -> BTreeMap<V, usize>
         }
 
         if !counted {
-            for (_i, c) in &mut counters {
+            for c in counters.values_mut() {
                 *c -= 1;
             }
 


### PR DESCRIPTION
Updates quantiles to 0.5.0. The major change here is the use of serde 1.0. There are no code changes but any project still using serde < 1.0 will have to make use of quantiles 0.4.

As well, serde is now an optional dependency for the project, reducing build-times and tree complexity for projects not needing to serialize CKMS. Projects needing that will have to enable the "serde_support" feature.