### PR TITLE
Repair the AddAssign of Histogram

### DIFF
--- a/src/greenwald_khanna.rs
+++ b/src/greenwald_khanna.rs
@@ -283,7 +283,7 @@ where
         assert!(i < self.summary.len() - 1);
 
         let t = self.summary.remove(i);
-        let mut tnext = &mut self.summary[i];
+        let tnext = &mut self.summary[i];
 
         tnext.g += t.g;
     }


### PR DESCRIPTION
This commit puts into place a QC test verifying the behaviour of
the AddAssign implementation of Histogram, shaking out bugs in the
process. @benley discovered the basic issue of Histogram bins not
summing correctly in context of https://github.com/postmates/cernan/pull/306.
This new test also uncovered that counts didn't work quite right.

Signed-off-by: Brian L. Troutwine <blt@postmates.com>